### PR TITLE
Fixed validation in the NamePicker component

### DIFF
--- a/src/qml/NamePicker.qml
+++ b/src/qml/NamePicker.qml
@@ -44,6 +44,11 @@ Kirigami.OverlaySheet {
     footer: QQC2.Button {
         id: buttonOk;
         width: parent.width;
+
+        // The check below is done to ensure we do not have to wait for the text to be accepted
+        // before enabling the button. The text will still be entered, but both need to be checked
+        // to ensure the expected behaviour (as the actual text does not get entered until the
+        // text box loses focus or the input is accepted).
         enabled: (enteredName.preeditText + enteredName.text).length;
 
         onClicked: {

--- a/src/qml/NamePicker.qml
+++ b/src/qml/NamePicker.qml
@@ -44,7 +44,7 @@ Kirigami.OverlaySheet {
     footer: QQC2.Button {
         id: buttonOk;
         width: parent.width;
-        enabled: enteredName.text.length;
+        enabled: (enteredName.preeditText + enteredName.text).length;
 
         onClicked: {
             control.namePicked(enteredName.text);


### PR DESCRIPTION
Fixed validation in the NamePicker component

Before these changes, we had to confirm the text entry twice or first enter a space